### PR TITLE
Allow Multiple Reducers per Action with Priority Handling

### DIFF
--- a/projects/ngx-mxstore/package.json
+++ b/projects/ngx-mxstore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mxstore",
-  "version": "19.0.3",
+  "version": "19.1.0",
   "author": "Maxxton Group",
   "repository": {
     "type": "git",

--- a/projects/ngx-mxstore/src/lib/decorators/reducer.decorator.ts
+++ b/projects/ngx-mxstore/src/lib/decorators/reducer.decorator.ts
@@ -1,22 +1,62 @@
 import {StoreService} from "../store.service";
 
-export function Reducer(action: any ): PropertyDecorator {
+export interface ReducerHandler {
+  propertyKey: string | symbol;
+  priority: number;
+}
+
+export function Reducer(action: any, priority?: number): PropertyDecorator {
   return ( target: Object, propertyKey: string | symbol ) => {
     const targetStoreService = target.constructor as unknown as StoreService<any>;
-    // register the action handler to the target (handling this action is done by the store service).
-    if (targetStoreService.actionHandlers && targetStoreService.actionHandlers?.[action.ACTION_TYPE]) {
-      throw new Error(`It is not possible to have multiple REDUCERS for the same action in the same service.
-      action: ${action.ACTION_TYPE}, reducer: ${target.constructor.name}.${Object(propertyKey)}`);
-    }
 
-    Object.defineProperty( target, 'actionHandlers', {
+    // Default priority is 0 if not specified
+    const reducerPriority = priority !== undefined ? priority : 0;
+
+    // Initialize actionHandlers if it doesn't exist
+    if (!targetStoreService.actionHandlers) {
+      Object.defineProperty( target, 'actionHandlers', {
         enumerable: true,
         configurable: true,
-        value: {
-          ...(target as StoreService<any>).actionHandlers,
-          [ action.ACTION_TYPE ]: propertyKey
-        }
+        value: {}
+      });
+    }
+
+    // Get existing handlers for this action type
+    const existingHandlers = targetStoreService.actionHandlers?.[action.ACTION_TYPE];
+    let handlersArray: ReducerHandler[] = [];
+
+    // Handle both old format (single propertyKey) and new format (array)
+    if (existingHandlers) {
+      if (Array.isArray(existingHandlers)) {
+        handlersArray = [...existingHandlers];
+      } else {
+        // Convert old format to new format (assume default priority 0)
+        handlersArray = [{ propertyKey: existingHandlers, priority: 0 }];
       }
-    );
+    }
+
+    // Check for duplicate priority
+    const duplicatePriority = handlersArray.find(h => h.priority === reducerPriority);
+    if (duplicatePriority) {
+      throw new Error(`It is not possible to have multiple REDUCERS with the same priority for the same action in the same service.
+      action: ${action.ACTION_TYPE}, priority: ${reducerPriority}, reducer: ${target.constructor.name}.${Object(propertyKey)}`);
+    }
+
+    // Add the new reducer handler
+    const newHandler: ReducerHandler = { propertyKey, priority: reducerPriority };
+    handlersArray.push(newHandler);
+
+    // Sort by priority (lower numbers = higher priority, executed first)
+    handlersArray.sort((a, b) => a.priority - b.priority);
+
+    // Update actionHandlers with the sorted array
+    Object.defineProperty( target, 'actionHandlers', {
+      enumerable: true,
+      configurable: true,
+      value: {
+        ...(target as StoreService<any>).actionHandlers,
+        [ action.ACTION_TYPE ]: handlersArray
+      }
+    });
   };
 }


### PR DESCRIPTION
Previously, our store architecture supported:

✅ Multiple effects per action — allowed and stored as an array, all executed independently.

❌ Multiple reducers per action — not allowed, throwing an error if attempted.

This limitation made sense because:

Effects are side effects that can safely run in parallel.

Reducers mutate state, so allowing multiple reducers could introduce ambiguity about which one’s result should take precedence.

Problem

As the application grows, developers often want to split logic into smaller, reusable store modules — instead of maintaining everything inside a single store.service.ts.
However, this modularization can lead to cases where multiple reducers need to respond to the same action (e.g., shared logic between stores or feature-specific state updates).

Under the current restriction, this is not possible.

Solution

This PR introduces support for multiple reducers per action, with an added priority system to ensure deterministic outcomes.

Reducers can now be registered with priorities.

When an action is dispatched:

All reducers listening to that action are executed in priority order.

The store’s final state reflects the result of the highest-priority reducer (or a controlled merge if defined).

This approach maintains predictability while enabling modularity and reusability of store logic.