### PR TITLE
Fix reducer decorator to use prototype-based actionHandlers storage

### DIFF
--- a/projects/ngx-mxstore/package.json
+++ b/projects/ngx-mxstore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mxstore",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "author": "Maxxton Group",
   "repository": {
     "type": "git",

--- a/projects/ngx-mxstore/src/lib/decorators/reducer.decorator.ts
+++ b/projects/ngx-mxstore/src/lib/decorators/reducer.decorator.ts
@@ -7,22 +7,11 @@ export interface ReducerHandler {
 
 export function Reducer(action: any, priority?: number): PropertyDecorator {
   return ( target: Object, propertyKey: string | symbol ) => {
-    const targetStoreService = target.constructor as unknown as StoreService<any>;
-
     // Default priority is 0 if not specified
     const reducerPriority = priority !== undefined ? priority : 0;
 
-    // Initialize actionHandlers if it doesn't exist
-    if (!targetStoreService.actionHandlers) {
-      Object.defineProperty( target, 'actionHandlers', {
-        enumerable: true,
-        configurable: true,
-        value: {}
-      });
-    }
-
-    // Get existing handlers for this action type
-    const existingHandlers = targetStoreService.actionHandlers?.[action.ACTION_TYPE];
+    // Get existing handlers
+    const existingHandlers = (target as StoreService<any>).actionHandlers?.[action.ACTION_TYPE];
     let handlersArray: ReducerHandler[] = [];
 
     // Handle both old format (single propertyKey) and new format (array)


### PR DESCRIPTION
This PR fixes an issue where reducer decorators were reading metadata from the class constructor instead of its prototype. Since decorators execute on the prototype, this mismatch caused every reducer decorator to see an empty actionHandlers object and overwrite it, resulting in only the last reducer being registered.