### PR TITLE
chore: update library to Angular 21 ↠

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,23 +10,23 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^20.3.9",
-    "@angular/common": "^20.3.9",
-    "@angular/compiler": "^20.3.9",
-    "@angular/core": "^20.3.9",
-    "@angular/forms": "^20.3.9",
-    "@angular/platform-browser": "^20.3.9",
-    "@angular/platform-browser-dynamic": "^20.3.9",
-    "@angular/router": "^20.3.9",
+    "@angular/animations": "^21.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/compiler": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
+    "@angular/platform-browser-dynamic": "^21.0.0",
+    "@angular/router": "^21.0.0",
     "lodash": "^4.17.21",
     "rxjs": "^7.8.1",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^20.3.9",
-    "@angular/cli": "~20.3.9",
-    "@angular/compiler-cli": "^20.3.9",
+    "@angular-devkit/build-angular": "^21.0.0",
+    "@angular/cli": "~21.0.0",
+    "@angular/compiler-cli": "^21.0.0",
     "@types/jasmine": "~4.0.0",
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.17.20",
@@ -36,7 +36,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "ng-packagr": "^20.0.0",
-    "typescript": "~5.8.3"
+    "ng-packagr": "^21.0.0",
+    "typescript": "~5.9.0"
   }
 }

--- a/projects/ngx-mxstore/package.json
+++ b/projects/ngx-mxstore/package.json
@@ -1,14 +1,14 @@
 {
   "name": "ngx-mxstore",
-  "version": "20.0.0",
+  "version": "21.0.0",
   "author": "Maxxton Group",
   "repository": {
     "type": "git",
     "url": "https://github.com/MaxxtonGroup/ngx-mxstore.git"
   },
   "peerDependencies": {
-    "@angular/common": "^20",
-    "@angular/core": "^20",
+    "@angular/common": "^21",
+    "@angular/core": "^21",
     "lodash": "^4.17.21"
   },
   "scripts": {
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.188",
-    "typescript": "~5.6.0"
+    "typescript": "~5.9.0"
   }
 }


### PR DESCRIPTION
- Update all @angular/* packages to ^21.0.0
- Update @angular/cli and build tools to ^21.0.0
- Update ng-packagr to ^21.0.0
- Update TypeScript to ~5.9.0 (required for Angular 21)
- Update library version to 21.0.0
- Update peerDependencies to Angular 21