### PR TITLE
Add Redux DevTools integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,25 @@ When you want to see the current contents of the store:
 __STATE.snapshot
 ```
 
+### Redux DevTools
+ngx-mxstore can connect to the [Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools), so you can inspect dispatched actions, view state diffs and time-travel through your application's state.
+
+Call `enableDevTools()` once during application startup (e.g. in `main.ts` or in your root component):
+```ts
+import { stateManagementTools } from 'ngx-mxstore';
+
+stateManagementTools.enableDevTools();
+```
+
+To disconnect again:
+```ts
+stateManagementTools.disableDevTools();
+```
+
+This requires the Redux DevTools browser extension to be installed. If it is not present, a warning is logged to the console and nothing else happens.
+
+Note: time-travel via "jump to action/state", "commit", "rollback", "reset" and "import state" is supported and directly overwrites the store's state. Since effects in ngx-mxstore are not pure functions of `(state, action)`, replaying actions on top of an older state (rather than jumping to a previously recorded state) is not supported.
+
 ## Advanced usage
 
 ### Limit the triggering of an effect

--- a/projects/ngx-mxstore/package.json
+++ b/projects/ngx-mxstore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mxstore",
-  "version": "21.0.0",
+  "version": "21.1.0",
   "author": "Maxxton Group",
   "repository": {
     "type": "git",

--- a/projects/ngx-mxstore/src/lib/action.service.ts
+++ b/projects/ngx-mxstore/src/lib/action.service.ts
@@ -66,5 +66,5 @@ class _ActionService {
 
 export const ActionService: typeof _ActionService = (window as any).__ACTIONS || _ActionService;
 
-(window as any).__ACTIONS = _ActionService;
+(window as any).__ACTIONS = ActionService;
 

--- a/projects/ngx-mxstore/src/lib/dev-tools.service.ts
+++ b/projects/ngx-mxstore/src/lib/dev-tools.service.ts
@@ -104,4 +104,4 @@ class _DevToolsService {
 
 export const DevToolsService: typeof _DevToolsService = ( window as any ).__DEVTOOLS || _DevToolsService;
 
-( window as any ).__DEVTOOLS = _DevToolsService;
+( window as any ).__DEVTOOLS = DevToolsService;

--- a/projects/ngx-mxstore/src/lib/dev-tools.service.ts
+++ b/projects/ngx-mxstore/src/lib/dev-tools.service.ts
@@ -1,0 +1,107 @@
+import { Subscription } from 'rxjs';
+import { ActionService, ActionTypeWithPayload } from './action.service';
+import { GlobalStateService } from './global-state.service';
+
+interface ReduxDevtoolsConnection {
+  init: ( state: any ) => void;
+  send: ( action: any, state: any ) => void;
+  subscribe: ( listener: ( message: any ) => void ) => void;
+  unsubscribe: () => void;
+}
+
+interface ReduxDevtoolsExtension {
+  connect: ( options?: { name?: string } ) => ReduxDevtoolsConnection;
+}
+
+export interface DevToolsOptions {
+  name?: string;
+}
+
+// tslint:disable-next-line:class-name
+class _DevToolsService {
+
+  private static connection: ReduxDevtoolsConnection | null = null;
+  private static initialState: { [ key: string ]: any } | null = null;
+  private static actionSubscription: Subscription | null = null;
+
+  /**
+   * connects to the Redux DevTools browser extension (if installed) and starts forwarding
+   * every dispatched action and the resulting state to it. Also allows the extension to
+   * time-travel the application by jumping to, committing or resetting state.
+   */
+  static enable( options: DevToolsOptions = {} ) {
+    const extension: ReduxDevtoolsExtension | undefined = ( window as any ).__REDUX_DEVTOOLS_EXTENSION__;
+
+    if ( !extension ) {
+      console.warn( 'ngx-mxstore: Redux DevTools extension was not found in this browser.' );
+      return;
+    }
+
+    if ( DevToolsService.connection ) {
+      return;
+    }
+
+    DevToolsService.connection = extension.connect( { name: options.name || 'ngx-mxstore' } );
+    DevToolsService.initialState = GlobalStateService.snapshot;
+    DevToolsService.connection.init( DevToolsService.initialState );
+
+    DevToolsService.actionSubscription = ActionService.onActions$().subscribe( ( action: ActionTypeWithPayload ) => {
+      // reducers/effects triggered synchronously by this action have run by the time this microtask executes.
+      Promise.resolve().then( () => {
+        DevToolsService.connection?.send( { type: action.type, payload: action.payload }, GlobalStateService.snapshot );
+      } );
+    } );
+
+    DevToolsService.connection.subscribe( ( message: any ) => DevToolsService.onDevToolsMessage( message ) );
+  }
+
+  /**
+   * disconnects from the Redux DevTools extension.
+   */
+  static disable() {
+    DevToolsService.actionSubscription?.unsubscribe();
+    DevToolsService.actionSubscription = null;
+    DevToolsService.connection?.unsubscribe();
+    DevToolsService.connection = null;
+    DevToolsService.initialState = null;
+  }
+
+  private static onDevToolsMessage( message: any ) {
+    if ( !DevToolsService.connection || message.type !== 'DISPATCH' ) {
+      return;
+    }
+
+    switch ( message.payload.type ) {
+      case 'JUMP_TO_ACTION':
+      case 'JUMP_TO_STATE':
+        DevToolsService.applyState( JSON.parse( message.state ) );
+        break;
+      case 'ROLLBACK':
+        DevToolsService.applyState( JSON.parse( message.state ) );
+        DevToolsService.connection.init( GlobalStateService.snapshot );
+        break;
+      case 'COMMIT':
+        DevToolsService.connection.init( GlobalStateService.snapshot );
+        break;
+      case 'RESET':
+        DevToolsService.applyState( DevToolsService.initialState || {} );
+        DevToolsService.connection.init( GlobalStateService.snapshot );
+        break;
+      case 'IMPORT_STATE': {
+        const computedStates = message.payload.nextLiftedState.computedStates;
+        DevToolsService.applyState( computedStates[ computedStates.length - 1 ].state );
+        DevToolsService.connection.send( null, GlobalStateService.snapshot );
+        break;
+      }
+    }
+  }
+
+  private static applyState( state: { [ key: string ]: any } ) {
+    GlobalStateService.setState( state, false );
+  }
+
+}
+
+export const DevToolsService: typeof _DevToolsService = ( window as any ).__DEVTOOLS || _DevToolsService;
+
+( window as any ).__DEVTOOLS = _DevToolsService;

--- a/projects/ngx-mxstore/src/lib/global-state.service.ts
+++ b/projects/ngx-mxstore/src/lib/global-state.service.ts
@@ -139,5 +139,5 @@ class _GlobalStateService {
 
 export const GlobalStateService: typeof _GlobalStateService = ( window as any ).__STATE || _GlobalStateService;
 
-( window as any ).__STATE = _GlobalStateService;
+( window as any ).__STATE = GlobalStateService;
 

--- a/projects/ngx-mxstore/src/lib/global-state.service.ts
+++ b/projects/ngx-mxstore/src/lib/global-state.service.ts
@@ -4,11 +4,12 @@ import { LogType, StoreLoggingUtil } from "./util/store-logging.util";
 import _ from 'lodash/fp';
 import {StringUtil} from './util/string.util';
 
-export class GlobalStateService {
+// tslint:disable-next-line:class-name
+class _GlobalStateService {
   private static globalState: { [ key: string ]: any } = {};
-  private static readonly globalStateChanges = new BehaviorSubject<any>( GlobalStateService.globalState );
+  private static readonly globalStateChanges = new BehaviorSubject<any>( _GlobalStateService.globalState );
   private static debugMode: boolean = false;
-  private static readonly globalStateChangesObs$ = GlobalStateService.globalStateChanges.asObservable().pipe(
+  private static readonly globalStateChangesObs$ = _GlobalStateService.globalStateChanges.asObservable().pipe(
     debounceTime( 20 ), // make sure state is stable for at least 20ms before we push an update to the interface.
     share(),
   );
@@ -136,5 +137,7 @@ export class GlobalStateService {
 
 }
 
-( window as any ).__STATE = GlobalStateService;
+export const GlobalStateService: typeof _GlobalStateService = ( window as any ).__STATE || _GlobalStateService;
+
+( window as any ).__STATE = _GlobalStateService;
 

--- a/projects/ngx-mxstore/src/lib/index.ts
+++ b/projects/ngx-mxstore/src/lib/index.ts
@@ -1,5 +1,6 @@
 import { ActionService } from "./action.service";
 import { GlobalStateService } from "./global-state.service";
+import { DevToolsService } from "./dev-tools.service";
 import { AssertUtil } from './util/assert.util';
 
 export { Action } from './decorators/action.decorator';
@@ -17,6 +18,7 @@ export { AssertUtil, StateNotChangedError } from "./util/assert.util";
 export { EffectStatus, CrudEffectStatus, ActionMeta, CrudEffectStringStatus } from './models/index';
 export { ActionService } from "./action.service";
 export { GlobalStateService } from "./global-state.service";
+export { DevToolsService, DevToolsOptions } from "./dev-tools.service";
 export { ReducerUtil } from "./util/reducer.util";
 export { NgxMxstoreModule } from "./ngx-mxstore.module";
 export { EffectTester } from "./testing/effect-tester";
@@ -27,10 +29,14 @@ const enableDebugState = GlobalStateService.enableDebugInfo;
 const disableDebugState = GlobalStateService.disableDebugInfo;
 const enableDebugActions = ActionService.enableDebugInfo;
 const disableDebugActions = ActionService.disableDebugInfo;
+const enableDevTools = DevToolsService.enable;
+const disableDevTools = DevToolsService.disable;
 
 export const stateManagementTools = {
   enableDebugState,
   enableDebugActions,
   disableDebugActions,
   disableDebugState,
+  enableDevTools,
+  disableDevTools,
 };


### PR DESCRIPTION
Lets consumers connect ngx-mxstore to the Redux DevTools browser extension via stateManagementTools.enableDevTools(), to inspect dispatched actions and time-travel through state. Also fixes GlobalStateService to reuse an existing window-bound instance instead of creating a new one on each module load (matching the existing pattern in ActionService), which otherwise caused DevToolsService to read from an empty, disconnected copy of the state.